### PR TITLE
Fixed support for Query String parameters

### DIFF
--- a/src/main/java/net/joelinn/asana/AbstractClient.java
+++ b/src/main/java/net/joelinn/asana/AbstractClient.java
@@ -83,7 +83,7 @@ public abstract class AbstractClient {
     private WebResource.Builder getResourceBuilder(String url, MultivaluedMapImpl queryParams){
         WebResource webResource = service.path(url);
         if(queryParams != null){
-            webResource.queryParams(queryParams);
+            webResource = webResource.queryParams(queryParams);
         }
         return webResource.accept(MediaType.APPLICATION_JSON).type(MediaType.APPLICATION_FORM_URLENCODED);
     }


### PR DESCRIPTION
webResource.queryParams(queryParams) returns a new WebResource instance
