### PR TITLE
Fixed error when creating clients with socket timeouts specified

### DIFF
--- a/src/main/java/net/joelinn/asana/Asana.java
+++ b/src/main/java/net/joelinn/asana/Asana.java
@@ -47,7 +47,7 @@ public class Asana {
             try {
                 AbstractClient client;
                 if(this.connectionTimeout != null && this.readTimeout != null){
-                    client = clazz.getConstructor(String.class, Integer.class, Integer.class)
+                    client = clazz.getConstructor(String.class, int.class, int.class)
                             .newInstance(apiKey, connectionTimeout, readTimeout);
                 }
                 else{

--- a/src/test/java/net/joelinn/asana/test/AsanaTest.java
+++ b/src/test/java/net/joelinn/asana/test/AsanaTest.java
@@ -23,4 +23,10 @@ public class AsanaTest extends BaseTest{
     public void testGetClient(){
         TestCase.assertEquals(ProjectsClient.class, client.projects().getClass());
     }
+
+    @Test
+    public void testGetClientWithTimeoutsSpecified() {
+    	client = new Asana(getApiKey(), 1, 1);
+        TestCase.assertEquals(ProjectsClient.class, client.projects().getClass());
+    }
 }


### PR DESCRIPTION
Api could not be used because the wrong datatype was used for constructor resolution.
